### PR TITLE
Undefined name: driver --> self.driver

### DIFF
--- a/grabber/google.py
+++ b/grabber/google.py
@@ -53,7 +53,7 @@ class GoogleGrabber:
                     self.driver.execute_script('''window.open("''' + link + '''","_blank");''')
                     time.sleep(2)
                     #switch to tab
-                    self.driver.switch_to.window(driver.window_handles[1])
+                    self.driver.switch_to.window(self.driver.window_handles[1])
                     time.sleep(1)
                     url = self.driver.current_url
                     self.driver.close()


### PR DESCRIPTION
__driver__ is an undefined name in this context which will raise NameError at runtime so this PR recommends using __self.driver__ which is already used previously on this same line of code.

[flake8](http://flake8.pycqa.org) testing of https://github.com/ThoughtfulDev/EagleEye on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
233./grabber/google.py:56:50: F821 undefined name 'driver'
234                    self.driver.switch_to.window(driver.window_handles[1])
235                                                 ^
2361     F821 undefined name 'driver'
2371
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.
