### PR TITLE
Do not use mutable data structures for argument defaults

### DIFF
--- a/eagle-eye.py
+++ b/eagle-eye.py
@@ -61,15 +61,15 @@ def getInstaLinks(username):
     instagrabber = InstagramGrabber(username)
     return instagrabber.getLinks()
 
-def main(skipFB=False, FBUrls=[], jsonRep=None, dockerMode=False, dockerName=None):
+def main(skipFB=False, FBUrls=None, jsonRep=None, dockerMode=False, dockerName=None):
+    FBUrls = FBUrls or []
     if not skipFB:
         # collect user input
         if dockerMode:
             console.section("Running in DOCKER MODE")
             name = dockerName
         else:
-            console.prompt('Enter the persons name to find on FB: ')
-            name = input('')
+            name = ''
             while not name:
                 console.prompt('Enter the persons name to find on FB: ')
                 name = input('')


### PR DESCRIPTION
https://docs.python-guide.org/writing/gotchas/

$ `python3 -m pip install flake8 flake8-bugbear`
$ `flake8`
```
./EagleEye/eagle-eye.py:64:31: B006 Do not use mutable data structures for argument defaults.  They are created
during function definition time. All calls to the function reuse this one instance of that data structure,
persisting changes between them.
def main(skipFB=False, FBUrls=[], jsonRep=None, dockerMode=False, dockerName=None):
                              ^
```